### PR TITLE
[Fix]修复网络中断后因音乐时长缺失导致的 NPE，并增加连续跳过保护

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="21" />
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="21" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/neoforge/neoforge-1.21.1/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.1/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.1/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.1/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.1/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.1/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",

--- a/neoforge/neoforge-1.21.10/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.10/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.10/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.10/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.10/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.10/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",

--- a/neoforge/neoforge-1.21.11/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.11/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.11/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.11/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.11/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.11/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",

--- a/neoforge/neoforge-1.21.2/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.2/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.2/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.2/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.2/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.2/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",

--- a/neoforge/neoforge-1.21.4/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.4/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.4/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.4/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.4/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.4/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",

--- a/neoforge/neoforge-1.21.5/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.5/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.6/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.6/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.6/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.6/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.6/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.6/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",

--- a/neoforge/neoforge-1.21.7/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
+++ b/neoforge/neoforge-1.21.7/src/main/java/top/gregtao/concerto/network/room/ServerMusicAgent.java
@@ -48,6 +48,36 @@ public class ServerMusicAgent {
     public ArrayList<Music> freeTimePlaylist = new ArrayList<>();
     private int freeTimePlaylistIndex = 0;
 
+    private int consecutiveSkips = 0;
+    private static final int MAX_SKIPS = 3;
+    private ScheduledFuture<?> recoveryFuture;
+
+    private void handleSkip(String logMsg, Object... args) {
+        ConcertoServer.LOGGER.warn(logMsg, args);
+        this.broadcast(Component.translatable("concerto.agent.play.failed",
+                this.currentMusic.getMeta().title(), this.currentMusic.getMeta().author()));
+
+        this.consecutiveSkips++;
+        if (this.consecutiveSkips >= MAX_SKIPS) {
+            ConcertoServer.LOGGER.warn("Too many consecutive skips, pausing music agent for 60 seconds");
+            this.broadcast(Component.translatable("concerto.agent.network.unstable"));
+            this.isPlaying.set(false);
+            this.currentMusic = null;
+            this.currentSharedMusic = null;
+            // 计划恢复任务
+            if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                this.recoveryFuture.cancel(false);
+            }
+            this.recoveryFuture = this.musicScheduler.schedule(() -> {
+                ConcertoServer.LOGGER.info("Attempting to resume music agent after network issue");
+                this.consecutiveSkips = 0;
+                this.schedulePlayNext(0, false);
+            }, 60, TimeUnit.SECONDS);
+        } else {
+            this.schedulePlayNext(0, false);
+        }
+    }
+
     public void stop() {
         if (this.isStopped.get()) return;
         this.isStopped.set(true);
@@ -157,6 +187,13 @@ public class ServerMusicAgent {
             } else {
                 ConcertoServer.LOGGER.info("Start playing music {}, duration {}",
                         this.currentMusic.getMeta().title(), this.currentMusic.getMeta().getDuration());
+
+                // 检查元数据是否完整，在获取元数据后立即检查时长
+                if (this.currentMusic.getMeta().getDuration() == null) {
+                    handleSkip("Duration missing for music {}, skipping", this.currentMusic.getMeta().title());
+                    return;
+                }
+
                 if (ServerConfig.INSTANCE.options.musicAgentUseShared && this.currentMusic instanceof DynamicPath dynamicPath) {
                     String path = dynamicPath.updateRawPath();
                     if (path != null) {
@@ -173,6 +210,14 @@ public class ServerMusicAgent {
                 } else {
                     this.currentSharedMusic = this.currentMusic;
                 }
+
+                // 正常播放，重置跳过计数器
+                this.consecutiveSkips = 0;
+                if (this.recoveryFuture != null && !this.recoveryFuture.isDone()) {
+                    this.recoveryFuture.cancel(false);
+                    this.recoveryFuture = null;
+                }
+
                 this.isPlaying.set(true);
                 this.playTime = System.currentTimeMillis();
                 ServerMusicNetworkHandler.musicAgentSendMusic(this.getMembers(), this.currentSharedMusic);
@@ -257,12 +302,17 @@ public class ServerMusicAgent {
         if (this.voteFuture != null) {
             this.voteFuture.cancel(true);
         }
+        if (this.recoveryFuture != null) {
+            this.recoveryFuture.cancel(true);
+            this.recoveryFuture = null;
+        }
         this.musicQueue.clear();
         this.currentMusic = this.currentSharedMusic = null;
         this.totalBytes = 0;
         this.playTime = 0;
         this.isPlaying.set(false);
         this.currentlyFreeTime.set(false);
+        this.consecutiveSkips = 0;
 
         ConcertoServer.LOGGER.info("Reset server music agent");
     }

--- a/neoforge/neoforge-1.21.7/src/main/resources/assets/concerto/lang/en_us.json
+++ b/neoforge/neoforge-1.21.7/src/main/resources/assets/concerto/lang/en_us.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "The music agent service is not available!",
   "concerto.agent.error": "Error occurs in server music agent.",
   "concerto.agent.add.too_quick": "You are requesting too quickly! Please retry after %d seconds.",
+  "concerto.agent.network.unstable": "Network unstable, music playback paused. Will retry in 60 seconds.",
 
   "concerto.error.invalid_path": "Invalid path or file format",
   "concerto.error.unsupported_operation": "Unsupported Operation!",

--- a/neoforge/neoforge-1.21.7/src/main/resources/assets/concerto/lang/zh_cn.json
+++ b/neoforge/neoforge-1.21.7/src/main/resources/assets/concerto/lang/zh_cn.json
@@ -252,6 +252,7 @@
   "concerto.agent.not_available": "点歌服务不可用",
   "concerto.agent.error": "使用点歌服务时遇到错误",
   "concerto.agent.add.too_quick": "请求过于频繁！请在 %d 秒后重试",
+  "concerto.agent.network.unstable": "网络不稳定，音乐播放已暂停。将在60秒后重试。",
 
   "concerto.error.invalid_path": "不可用的路径或文件格式",
   "concerto.error.unsupported_operation": "不支持的操作！",


### PR DESCRIPTION
### 问题：
当服务器网络短暂中断后恢复时，点播的歌曲虽然能正常播放音频，但元数据（如时长 duration）可能因请求失败而缺失，导致 ServerMusicAgent.playNextMusic() 中调用 getDuration().asSeconds() 时抛出 NullPointerException，并使音乐播放功能异常（显示“Unknown”，后续歌曲也无法正常播放）。该问题可稳定复现。
#1 
### 修复内容：
**增加时长空值检查**
在 playNextMusic() 方法中，获取音乐元数据后立即检查 getDuration() 是否为空。若为空，则跳过当前歌曲并记录警告，避免 NPE。
**增加连续跳过保护**
若连续跳过 3 首歌曲（可能是网络持续不稳定），则暂停音乐代理 60 秒，并广播通知玩家。60 秒后自动重试播放。避免因网络问题导致以极快速度遍历整个歌单，同时给予网络恢复的时间。
**添加相关本地化键**
新增 concerto.agent.network.unstable 键，用于广播网络不稳定时的提示信息（已添加至 zh_cn.json 和 en_us.json）。

### 修复范围：
fabric版本和forge版本很可能也存在该问题，暂时只修复了neoforge版本，目前修改了neoforge1.21.1-1.21.11的所有版本，1.21.1版本经过测试一切正常，其他版本的ServerMusicAgent.java内容几乎一致，因此直接进行了修改未进行测试，